### PR TITLE
Fix compiling error on Solaris

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ TARSOURCES = Makefile *.c  *.h \
 	pg_store_plans.control \
 	doc/* expected/*.out sql/*.sql \
 
+ifneq ($(shell uname), SunOS)
 LDFLAGS+=-Wl,--build-id
+endif
 
 ## These entries need running server
 DBNAME = postgres


### PR DESCRIPTION
The 'LDFLAGS+=-Wl,--build-id' option is for rpm building in Linux like
OS.  The SunOS is not native support the option
'LDFLAGS+=-Wl,--build-id' . So, disable this option in SunOS while
compiling.