### PR TITLE
Several fixes on recent changes

### DIFF
--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -419,7 +419,7 @@ _PG_init(void)
 							 &plan_storage,
 							 PLAN_STORAGE_FILE,
 							 plan_storage_options,
-							 PGC_USERSET,
+							 PGC_POSTMASTER,
 							 0,
 							 NULL,
 							 NULL,

--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -83,8 +83,7 @@ static int max_plan_len = 5000;
 #define STICKY_DECREASE_FACTOR	(0.50)	/* factor for sticky entries */
 #define USAGE_DEALLOC_PERCENT	5		/* free this % of entries at once */
 
-/* In PostgreSQL 11, queryid becomes a uint64 internally.
- */
+/* In PostgreSQL 11, queryid becomes a uint64 internally. */
 #if PG_VERSION_NUM >= 110000
 typedef uint64 queryid_t;
 #define PGSP_NO_QUERYID		UINT64CONST(0)

--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -1471,15 +1471,19 @@ pg_store_plans_internal(FunctionCallInfo fcinfo,
 		{
 			values[i++] = Int64GetDatumFast(queryid);
 			values[i++] = Int64GetDatumFast(planid);
+
+			/* fill queryid_stat_statements with the same value with queryid */
 			if (api_version == PGSP_V1_5)
-				values[i++] = ObjectIdGetDatum(queryid);
+				values[i++] = Int64GetDatumFast(queryid);
 		}
 		else
 		{
-			values[i++] = Int64GetDatumFast(0);
-			values[i++] = Int64GetDatumFast(0);
+			nulls[i++] = true;	/* queryid */
+			nulls[i++] = true;	/* planid */
+
+			/* queryid_stat_statemetns*/
 			if (api_version == PGSP_V1_5)
-				values[i++] = Int64GetDatumFast(0);
+				nulls[i++] = true;
 		}
 
 		if (is_allowed_role || entry->key.userid == userid)

--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -578,7 +578,7 @@ pgsp_shmem_startup(void)
 {
 	bool		found;
 	HASHCTL		info;
-	FILE	   *file;
+	FILE	   *file = NULL;
 	FILE	   *pfile = NULL;
 	uint32		header;
 	int32		num;
@@ -1512,6 +1512,7 @@ pg_store_plans_internal(FunctionCallInfo fcinfo,
 					mstr = pgsp_json_xmlize(pstr);
 					break;
 				default:
+					mstr = pstr;
 					break;
 			}
 
@@ -1746,6 +1747,9 @@ entry_dealloc(void)
 	entries = palloc(hash_get_num_entries(hash_table) * sizeof(pgspEntry *));
 
 	i = 0;
+	tottextlen = 0;
+	nvalidtexts = 0;
+
 	hash_seq_init(&hash_seq, hash_table);
 	while ((entry = hash_seq_search(&hash_seq)) != NULL)
 	{


### PR DESCRIPTION
As Julien pointed, the new GUC plan_storage shouldbe PGC_POSTMASTER(1),  and we should use Int64GetDatum(Fast) for queryid since it is an int64. On the way fixing it I noticed that Int64GetDatumFast is fed with a constant, which is not the proper use.  Actually build fails for !USE_FLOAT_BYVAL servers. Fix them together (2). Finally, I'm not sure how come I pushed that with that state, but compiler complains about some uninitialized variables so fix it(3).