### PR TITLE
Fix compatility with pg15 new shmem_request_hook.

### DIFF
--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -296,7 +296,6 @@ static bool force_disabled = false;
 /*---- Function declarations ----*/
 
 void		_PG_init(void);
-void		_PG_fini(void);
 
 Datum		pg_store_plans_reset(PG_FUNCTION_ARGS);
 Datum		pg_store_plans_hash_query(PG_FUNCTION_ARGS);
@@ -559,21 +558,6 @@ _PG_init(void)
 	ExecutorEnd_hook = pgsp_ExecutorEnd;
 	prev_ProcessUtility = ProcessUtility_hook;
 	ProcessUtility_hook = pgsp_ProcessUtility;
-}
-
-/*
- * Module unload callback
- */
-void
-_PG_fini(void)
-{
-	/* Uninstall hooks. */
-	shmem_startup_hook = prev_shmem_startup_hook;
-	ExecutorStart_hook = prev_ExecutorStart;
-	ExecutorRun_hook = prev_ExecutorRun;
-	ExecutorFinish_hook = prev_ExecutorFinish;
-	ExecutorEnd_hook = prev_ExecutorEnd;
-	ProcessUtility_hook = prev_ProcessUtility;
 }
 
 /*


### PR DESCRIPTION
I also entirely removed the _PG_fini() function, which was removed upstream in ab02d702ef08343fba30d90fdf7df5950063e8c9.

This function hasn't been called in a very long time (since 602a9ef5a7c in 2009) so it doesn't seem worth bothering defining and maintaining it for older major versions.