### PR TITLE
Fix compiling error on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ TARSOURCES = Makefile *.c  *.h \
 	pg_store_plans.control \
 	docs/* expected/*.out sql/*.sql \
 
-ifneq ($(shell uname), SunOS)
+ifeq ($(filter solaris% darwin%,$(host_os)),)
 LDFLAGS+=-Wl,--build-id
 endif
 


### PR DESCRIPTION
Mac OS linker(/usr/bin/ld) doesn't have "--build-id" option. Same as Solaris in #6. So I filtered it out in Makefile
```
uname -a
Darwin hompers-mbp 20.2.0 Darwin Kernel Version 20.2.0: Wed Dec  2 20:39:59 PST 2020; root:xnu-7195.60.75~1/RELEASE_X86_64 x86_64

sw_vers
ProductName:	macOS
ProductVersion:	11.1
BuildVersion:	20C69
```

```
ld --build-id
ld: unknown option: --build-id

gcc-11 -Wl,--build-id
ld: unknown option: --build-id
collect2: error: ld returned 1 exit status

clang -Wl,--build-id
ld: unknown option: --build-id
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```

Checked that build in Solaris 11 still works.