### PR TITLE
Add a null-check for stored plan text in pg_store_plans_internal().

### DIFF
--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -1579,6 +1579,12 @@ pg_store_plans_internal(FunctionCallInfo fcinfo,
 			else
 				pstr = SHMEM_PLAN_PTR(entry);
 
+			if (pstr == NULL)
+			{
+				values[i++] = CStringGetTextDatum("<invalid plan>");
+				goto outofblock01;
+			}
+
 			switch (plan_format)
 			{
 				case PLAN_FORMAT_TEXT:
@@ -1612,9 +1618,12 @@ pg_store_plans_internal(FunctionCallInfo fcinfo,
 				pfree(mstr);
 
 			/* pstr is a pointer onto pbuffer */
+
 		}
 		else
 			values[i++] = CStringGetTextDatum("<insufficient privilege>");
+
+		outofblock01:
 
 		/* copy counters to a local variable to keep locking time short */
 		{


### PR DESCRIPTION
Variable pstr retrieved from function ptext_fetch() can be NULL due to various factors.  Previously, pstr was passed as-is to each per-format process and used in strlen(), causing a crash when it was NULL.

This is a fix for #34 issue.
https://github.com/ossc-db/pg_store_plans/issues/34