### PR TITLE
Add PostgreSQL 17 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 17
           - 16
           - 15
           - 14

--- a/expected/store.out
+++ b/expected/store.out
@@ -1,10 +1,10 @@
 SET client_min_messages = 'error';
 CREATE EXTENSION IF NOT EXISTS pg_store_plans;
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-SELECT pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
+ t 
+---
+ t
 (1 row)
 
 SELECT pg_store_plans_reset();

--- a/expected/store_2.out
+++ b/expected/store_2.out
@@ -1,10 +1,10 @@
 SET client_min_messages = 'error';
 CREATE EXTENSION IF NOT EXISTS pg_store_plans;
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-SELECT pg_stat_statements_reset();
- pg_stat_statements_reset 
---------------------------
- 
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
+ t 
+---
+ t
 (1 row)
 
 SELECT pg_store_plans_reset();

--- a/pgsp_token_types.h
+++ b/pgsp_token_types.h
@@ -1,0 +1,67 @@
+/*-------------------------------------------------------------------------
+ *
+ * pgsp_json.c: Plan handler for JSON/XML/YAML style plans
+ *
+ * Copyright (c) 2012-2024, NIPPON TELEGRAPH AND TELEPHONE CORPORATION
+ *
+ * IDENTIFICATION
+ *	  pg_store_plans/pgsp_json.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+/* In PG16, include/scan.h was gone. Define required symbols manually.. */
+/* must be in sync with src/backend/parser/gram.h */
+#if PG_VERSION_NUM < 160000
+#error This file should only be included for PostgreSQL 16 and above
+#elif PG_VERSION_NUM < 170000
+enum pgsptokentype
+{
+    IDENT = 258,                   /* IDENT  */
+    FCONST = 260,                  /* FCONST  */
+    SCONST = 261,                  /* SCONST  */
+    BCONST = 263,                  /* BCONST  */
+    XCONST = 264,                  /* XCONST  */
+    Op = 265,                      /* Op  */
+    ICONST = 266,                  /* ICONST  */
+    CURRENT_CATALOG = 358,         /* CURRENT_CATALOG  */
+    CURRENT_DATE = 359,            /* CURRENT_DATE  */
+    CURRENT_ROLE = 360,            /* CURRENT_ROLE  */
+    CURRENT_SCHEMA = 361,          /* CURRENT_SCHEMA  */
+    CURRENT_TIME = 362,            /* CURRENT_TIME  */
+    CURRENT_TIMESTAMP = 363,       /* CURRENT_TIMESTAMP  */
+    CURRENT_USER = 364,            /* CURRENT_USER  */
+    FALSE_P = 415,                 /* FALSE_P  */
+    LOCALTIME = 502,               /* LOCALTIME  */
+    LOCALTIMESTAMP = 503,          /* LOCALTIMESTAMP  */
+    NULL_P = 540,                  /* NULL_P  */
+    TRUE_P = 689,                  /* TRUE_P  */
+};
+#elif PG_VERSION_NUM < 180000
+enum pgsptokentype
+{
+    IDENT = 258,                   /* IDENT  */
+    FCONST = 260,                  /* FCONST  */
+    SCONST = 261,                  /* SCONST  */
+    BCONST = 263,                  /* BCONST  */
+    XCONST = 264,                  /* XCONST  */
+    Op = 265,                      /* Op  */
+    ICONST = 266,                  /* ICONST  */
+    CURRENT_CATALOG = 359,         /* CURRENT_CATALOG  */
+    CURRENT_DATE = 360,            /* CURRENT_DATE  */
+    CURRENT_ROLE = 361,            /* CURRENT_ROLE  */
+    CURRENT_SCHEMA = 362,          /* CURRENT_SCHEMA  */
+    CURRENT_TIME = 363,            /* CURRENT_TIME  */
+    CURRENT_TIMESTAMP = 364,       /* CURRENT_TIMESTAMP  */
+    CURRENT_USER = 365,            /* CURRENT_USER  */
+    FALSE_P = 418,                 /* FALSE_P  */
+    LOCALTIME = 512,               /* LOCALTIME  */
+    LOCALTIMESTAMP = 513,          /* LOCALTIMESTAMP  */
+    NULL_P = 552,                  /* NULL_P  */
+    TRUE_P = 708,                  /* TRUE_P  */
+};
+#else
+#error This version of PostgeSQL is not supported
+#endif

--- a/sql/store.sql
+++ b/sql/store.sql
@@ -1,7 +1,7 @@
 SET client_min_messages = 'error';
 CREATE EXTENSION IF NOT EXISTS pg_store_plans;
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-SELECT pg_stat_statements_reset();
+SELECT pg_stat_statements_reset() IS NOT NULL AS t;
 SELECT pg_store_plans_reset();
 
 DROP TABLE IF EXISTS t1;


### PR DESCRIPTION
Postgres 17 changed some of the lexer token numbering, so introduce a new pgsp_token_types.h file to force the declaration of the needed token per major version and avoid using wrong values.

The JsonLexContext structure changed again and added extra ability to free part of the struct, which leads to wrong parsing results if not setup correctly. Fortunately upstream makeJsonLexContextCstringLen() has been changed to handle stack-allocated structs so we can now rely on this function from now on to avoid misbehavior in case of further changes to JsonLexContext.

blk_read_time and blk_write_time BufferUsage fields have been renamed to include a "shared" prefix, so handle it.

Finally, enable test on pg17 in the CI.