### PR TITLE
Add PostgreSQL 19 support

### DIFF
--- a/pg_store_plans.c
+++ b/pg_store_plans.c
@@ -44,6 +44,7 @@
 #include "commands/explain_state.h"
 #endif
 #include "access/hash.h"
+#include "access/htup_details.h"
 #if PG_VERSION_NUM >= 90500
 #include "access/parallel.h"
 #endif
@@ -60,6 +61,7 @@
 #include "tcop/utility.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/tuplestore.h"
 #if PG_VERSION_NUM >= 160000
 #include "nodes/queryjumble.h"
 #elif PG_VERSION_NUM >= 140000
@@ -688,10 +690,23 @@ pgsp_shmem_startup(void)
 	info.entrysize = sizeof(pgspEntry);
 	if (plan_storage == PLAN_STORAGE_SHMEM)
 		info.entrysize += max_plan_len;
+	/*
+	 * ShmemInitHash() dropped its separate init_size/max_size arguments in
+	 * favor of a single nelems argument in PG19 (the hash table is always
+	 * created at its final size up front, same as store_size was used for
+	 * both arguments here already).
+	 */
+#if PG_VERSION_NUM >= 190000
+	hash_table = ShmemInitHash("pg_store_plans hash",
+								store_size,
+								&info, HASH_ELEM |
+								HASH_BLOBS);
+#else
 	hash_table = ShmemInitHash("pg_store_plans hash",
 							  store_size, store_size,
 							  &info, HASH_ELEM |
 							  HASH_BLOBS);
+#endif
 
 	LWLockRelease(AddinShmemInitLock);
 
@@ -984,11 +999,23 @@ pgsp_ExecutorStart(QueryDesc *queryDesc, int eflags)
 			(log_buffers ? INSTRUMENT_BUFFERS : 0);
 	}
 
+#if PG_VERSION_NUM >= 190000
+	/*
+	 * As of PG19, top-of-query instrumentation ("totaltime") is requested
+	 * via query_instr_options before the executor starts, and the core
+	 * executor allocates/manages queryDesc->query_instr on its own; there's
+	 * no more InstrAlloc() call for callers to make here.
+	 */
+	if (!IsParallelWorker() && pgsp_enabled(queryDesc->plannedstmt->queryId))
+		queryDesc->query_instr_options |= INSTRUMENT_ALL;
+#endif
+
 	if (prev_ExecutorStart)
 		prev_ExecutorStart(queryDesc, eflags);
 	else
 		standard_ExecutorStart(queryDesc, eflags);
 
+#if PG_VERSION_NUM < 190000
 	/*
 	 * Set up to track total elapsed time in ExecutorRun. Allocate in per-query
 	 * context so as to be free at ExecutorEnd.
@@ -1006,6 +1033,7 @@ pgsp_ExecutorStart(QueryDesc *queryDesc, int eflags)
 										 );
 		MemoryContextSwitchTo(oldcxt);
 	}
+#endif
 
 }
 
@@ -1083,6 +1111,53 @@ pgsp_ExecutorFinish(QueryDesc *queryDesc)
 static void
 pgsp_ExecutorEnd(QueryDesc *queryDesc)
 {
+#if PG_VERSION_NUM >= 190000
+	if (!IsParallelWorker() && queryDesc->query_instr)
+	{
+		double		total_time = INSTR_TIME_GET_DOUBLE(queryDesc->query_instr->total);
+
+		if (pgsp_enabled(queryDesc->plannedstmt->queryId) &&
+			total_time >= (double) min_duration / 1000.0)
+		{
+			queryid_t	  queryid;
+			ExplainState *es;
+			StringInfo	  es_str;
+
+			es = NewExplainState();
+			es_str = es->str;
+
+			es->analyze = queryDesc->instrument_options;
+			es->verbose = log_verbose;
+			es->buffers = (es->analyze && log_buffers);
+			es->timing = (es->analyze && log_timing);
+			es->format = EXPLAIN_FORMAT_JSON;
+
+			ExplainBeginOutput(es);
+			ExplainPrintPlan(es, queryDesc);
+			if (log_triggers)
+				pgspExplainTriggers(es, queryDesc);
+			ExplainEndOutput(es);
+
+			/* Remove last line break */
+			if (es_str->len > 0 && es_str->data[es_str->len - 1] == '\n')
+				es_str->data[--es_str->len] = '\0';
+
+			/* JSON outmost braces. */
+			es_str->data[0] = '{';
+			es_str->data[es_str->len - 1] = '}';
+
+			queryid = queryDesc->plannedstmt->queryId;
+			Assert(queryid != PGSP_NO_QUERYID);
+
+			pgsp_store(es_str->data,
+						queryid,
+						total_time * 1000.0,	/* convert to msec */
+						queryDesc->estate->es_processed,
+						&queryDesc->query_instr->bufusage);
+			pfree(es_str->data);
+		}
+	}
+#else
 	if (!IsParallelWorker() && queryDesc->totaltime)
 	{
 		/*
@@ -1147,6 +1222,7 @@ pgsp_ExecutorEnd(QueryDesc *queryDesc)
 			pfree(es_str->data);
 		}
 	}
+#endif
 
 	if (prev_ExecutorEnd)
 		prev_ExecutorEnd(queryDesc);

--- a/pgsp_explain.c
+++ b/pgsp_explain.c
@@ -157,19 +157,36 @@ report_triggers(ResultRelInfo *rInfo, bool show_relname, ExplainState *es)
 	for (nt = 0; nt < rInfo->ri_TrigDesc->numtriggers; nt++)
 	{
 		Trigger    *trig = rInfo->ri_TrigDesc->triggers + nt;
+#if PG_VERSION_NUM >= 190000
+		/*
+		 * PG19 split trigger timing/firing counts out of the general
+		 * Instrumentation struct into a dedicated TriggerInstrumentation
+		 * struct (see commit "instrumentation: Separate trigger logic from
+		 * other uses"). ri_TrigInstrument is now an array of those.
+		 */
+		TriggerInstrumentation *tginstr = rInfo->ri_TrigInstrument + nt;
+#else
 		Instrumentation *instr = rInfo->ri_TrigInstrument + nt;
+#endif
 		char	   *relname;
 		char	   *conname = NULL;
 
+#if PG_VERSION_NUM < 190000
 		/* Must clean up instrumentation state */
 		InstrEndLoop(instr);
+#endif
 
 		/*
 		 * We ignore triggers that were never invoked; they likely aren't
 		 * relevant to the current query type.
 		 */
+#if PG_VERSION_NUM >= 190000
+		if (tginstr->firings == 0)
+			continue;
+#else
 		if (instr->ntuples == 0)
 			continue;
+#endif
 
 		pgspExplainOpenGroup("Trigger", NULL, true, es);
 
@@ -181,8 +198,15 @@ report_triggers(ResultRelInfo *rInfo, bool show_relname, ExplainState *es)
 		if (conname)
 			pgspExplainPropertyText("Constraint Name", conname, es);
 		pgspExplainPropertyText("Relation", relname, es);
+#if PG_VERSION_NUM >= 190000
+		pgspExplainPropertyFloat("Time",
+								  1000.0 * INSTR_TIME_GET_DOUBLE(tginstr->instr.total),
+								  3, es);
+		pgspExplainPropertyFloat("Calls", (double) tginstr->firings, 0, es);
+#else
 		pgspExplainPropertyFloat("Time", 1000.0 * instr->total, 3, es);
 		pgspExplainPropertyFloat("Calls", instr->ntuples, 0, es);
+#endif
 
 		if (conname)
 			pfree(conname);

--- a/pgsp_json.c
+++ b/pgsp_json.c
@@ -522,8 +522,12 @@ normalize_expr(char *expr, bool preserve_space)
 	/*
 	 * The warnings about nonstandard escape strings is already emitted in the
 	 * core. Just silence them here.
+	 *
+	 * The escape_string_warning field was removed from core_yy_extra_type in
+	 * PG19 as part of the scanner cleanup, so this is a no-op from that
+	 * version onward.
 	 */
-#if PG_VERSION_NUM >= 90500
+#if PG_VERSION_NUM >= 90500 && PG_VERSION_NUM < 190000
 	yyextra.escape_string_warning = false;
 #endif
 	lasttok = 0;

--- a/pgsp_token_types.h
+++ b/pgsp_token_types.h
@@ -63,6 +63,30 @@ enum pgsptokentype
     NULL_P = 552,                  /* NULL_P  */
     TRUE_P = 708,                  /* TRUE_P  */
 };
+#elif PG_VERSION_NUM < 200000
+/* Values verified against a bison-generated gram.h for PG 19beta1. */
+enum pgsptokentype
+{
+    IDENT = 258,                   /* IDENT  */
+    FCONST = 260,                  /* FCONST  */
+    SCONST = 261,                  /* SCONST  */
+    BCONST = 263,                  /* BCONST  */
+    XCONST = 264,                  /* XCONST  */
+    Op = 265,                      /* Op  */
+    ICONST = 266,                  /* ICONST  */
+    CURRENT_CATALOG = 359,         /* CURRENT_CATALOG  */
+    CURRENT_DATE = 360,            /* CURRENT_DATE  */
+    CURRENT_ROLE = 361,            /* CURRENT_ROLE  */
+    CURRENT_SCHEMA = 362,          /* CURRENT_SCHEMA  */
+    CURRENT_TIME = 363,            /* CURRENT_TIME  */
+    CURRENT_TIMESTAMP = 364,       /* CURRENT_TIMESTAMP  */
+    CURRENT_USER = 365,            /* CURRENT_USER  */
+    FALSE_P = 421,                 /* FALSE_P  */
+    LOCALTIME = 518,               /* LOCALTIME  */
+    LOCALTIMESTAMP = 519,          /* LOCALTIMESTAMP  */
+    NULL_P = 560,                  /* NULL_P  */
+    TRUE_P = 725,                  /* TRUE_P  */
+};
 #else
 #error This version of PostgeSQL is not supported
 #endif


### PR DESCRIPTION
Changelog:

- pgsp_token_types.h: Add a PG19 branch (PG_VERSION_NUM < 200000) for the hand-maintained core-scanner token enum. Values were not guessed: they were extracted from a bison-generated gram.h built from the actual PostgreSQL 19beta1 gram.y (CURRENT_CATALOG et al. stayed the same; FALSE_P/LOCALTIME/LOCALTIMESTAMP/NULL_P/TRUE_P shifted up because new keywords were inserted ahead of them in the grammar). This fixes the "#error This version of PostgeSQL is not supported" and the resulting cascade of ~20 "undeclared identifier" errors in pgsp_json.c (Op, SCONST, IDENT, FCONST, BCONST, XCONST, ICONST, NULL_P, TRUE_P, FALSE_P, CURRENT_*, LOCALTIME[STAMP]).

- pgsp_json.c: Guard the `yyextra.escape_string_warning = false;` assignment to PG_VERSION_NUM < 190000. The field was removed from core_yy_extra_type in PG19's scanner cleanup, so it no longer exists to assign to; the warning it used to silence isn't emitted by the core scanner in PG19 either, so simply skipping the assignment is correct.

- pgsp_explain.c (report_triggers): PG19 split per-trigger EXPLAIN ANALYZE timing out of the general Instrumentation struct into a new TriggerInstrumentation struct (upstream commit "instrumentation: Separate trigger logic from other uses"). ri_TrigInstrument is now an array of TriggerInstrumentation, exposing firing counts via ->firings and timing via ->instr.total (an instr_time, not a bare double). Added a PG_VERSION_NUM >= 190000 branch that mirrors upstream explain.c's report_triggers(): reads tginstr->firings/tginstr->instr.total instead of instr->ntuples/instr->total, and drops the manual InstrEndLoop() call that's no longer needed/applicable for triggers in PG19. This fixes the "incompatible pointer types", "no member named 'ntuples'", and "invalid operands to binary expression" errors.

- pg_store_plans.c:
  * Add missing #include "access/htup_details.h" and #include "utils/tuplestore.h". PG19's funcapi.h/executor headers no longer pull these in transitively, so heap_form_tuple(), tuplestore_begin_heap(), and tuplestore_putvalues() were showing up as implicit-function-declaration errors even though the functions themselves are unchanged.
  * ShmemInitHash(): PG19 collapsed the old (init_size, max_size) pair into a single `nelems` argument (4-arg signature instead of 5-arg). Since pg_store_plans already always passed store_size for both arguments, this is a mechanical drop of the duplicate argument, version-gated on PG_VERSION_NUM >= 190000.
  * pgsp_ExecutorStart()/pgsp_ExecutorEnd(): PG19 removed QueryDesc->totaltime entirely and reworked top-of-query instrumentation around QueryDesc->query_instr / query_instr_options, managed by the core executor instead of by extensions calling InstrAlloc()/ InstrEndLoop() by hand (mirrors the same change already made in contrib/pg_stat_statements and contrib/auto_explain upstream). Added a PG_VERSION_NUM >= 190000 branch that requests INSTRUMENT_ALL via query_instr_options before the executor starts, and reads timing/buffer usage back out of queryDesc->query_instr in ExecutorEnd using INSTR_TIME_GET_DOUBLE(). The pre-19 code path (totaltime/InstrAlloc/ InstrEndLoop) is preserved unchanged for older versions.

Hacked by Claude, tested by me. So please double check the patch.

Per: https://github.com/pgdg-packaging/pgdg-rpms/issues/213